### PR TITLE
修改解析过后生成模块名前缀有/字符的bug

### DIFF
--- a/tasks/lib/unwrap.js
+++ b/tasks/lib/unwrap.js
@@ -27,7 +27,7 @@ function replaceRequire (code, fn) {
 function toId (id) {
 	return id
 	.replace(/^\//, '')
-	.replace(/\\/g, '/')
+	.replace(/\\/g, '')
 	.replace(/\.js$/, '');
 }
 

--- a/tasks/lib/unwrap.js
+++ b/tasks/lib/unwrap.js
@@ -26,8 +26,8 @@ function replaceRequire (code, fn) {
 
 function toId (id) {
 	return id
+	.replace(/\\/g, '/')
 	.replace(/^\//, '')
-	.replace(/\\/g, '')
 	.replace(/\.js$/, '');
 }
 


### PR DESCRIPTION
由于用`path.resolve()`方法解析过`options.base`后，末尾不会有`"/"`字符，因此在`combo()`方法中，`var id = toId(file.replace(base, ''));`语句生成的`id`开头有多余的`"/"`字符，导致生成的不依赖模块加载器的版本中，模块名开头有多余`"/"`字符，在运行时会出错。实际上在artDialog项目中运行`grunt`命令后重新生成的文件在运行时也是会报错的。

解决方案是修改`toId()`方法，修改替换顺序，先替换所有`"\"`，再替换开头的`"/"`，这样生成的模块名开头不会有多余的`"/"`字符。
